### PR TITLE
Use correct activation script

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,10 @@
     language: node
     entry: dependency-consistency
     pass_filenames: false
+    additional_dependencies:
+        - "@yarnpkg/lockfile@1.1.0"
+        - "semver-sort@1.0.0"
+        - "yaml@1.10.2"
     stages:
         - commit
         - manual

--- a/run.sh
+++ b/run.sh
@@ -4,24 +4,12 @@ set -euo pipefail
 function get_root_dir () {
     local here
     here="$(realpath "$(dirname "$0")")"
-    if [[ "$here" == *"/node_env-default/bin" ]]; then
-        echo "$here" | sed -e 's|^\(.*\)/node_env-default/bin$|\1|'
-    else
-        echo "$here"
-    fi
+    while [[ ! -f "$here/run.sh" ]] && [[ "$here" != "/" ]]; do
+        here=$(realpath "$here/..")
+    done
+    echo "$here"
 }
 
 readonly ROOT_DIR="$(get_root_dir)"
 
-if [[ -d "$ROOT_DIR/node_modules" ]]; then
-    readonly NODE_MODULES="$ROOT_DIR/node_modules"
-else
-    readonly NODE_MODULES="$ROOT_DIR/node_env-default/lib/node_modules/dependency-consistency/node_modules"
-fi
-
-set +u
-# It may contained undefined variables
-source "$ROOT_DIR/node_env-default/bin/activate"
-set -u
-
-NODE_PATH="$NODE_MODULES" "node" "$ROOT_DIR/index.js" "$@"
+node "$ROOT_DIR/index.js" "$@"


### PR DESCRIPTION
When using it in a pre-commit hook running on GitHub Actions, the path to `activate` is incorrect.