### PR TITLE
[fix] Assign updated dependencies to `additional_dependencies`

### DIFF
--- a/scripts/keep-own-dependencies-up-to-date.cjs
+++ b/scripts/keep-own-dependencies-up-to-date.cjs
@@ -25,7 +25,7 @@ hooks.forEach(hook => {
             updatedDependecies.push(dependency)
         }
     })
-    hook = updatedDependecies
+    hook.additional_dependencies = updatedDependecies
 })
 
 fs.writeFileSync(".pre-commit-hooks.yaml", YAML.stringify(hooks, {


### PR DESCRIPTION
Missed during #12 