### PR TITLE
[fix] Properly replace node dependencies with namespace

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -170,7 +170,7 @@ function updateDependencies() {
         let content = readFile(PRE_COMMIT_YAML)
         Object.keys(mapping).forEach((previousVersion) => {
             const newVersion = mapping[previousVersion]
-            content = content.replace(new RegExp(`\n( +- *"?)${previousVersion}("? *#.*)?\n`, "gi"), "\n$1" + newVersion + "$2\n")
+            content = content.replace(new RegExp(`( +- *["']?)${previousVersion}(["']? *#.*)?`, "gi"), "$1" + newVersion + "$2")
         })
         fs.writeFileSync(PRE_COMMIT_YAML, content)
     }


### PR DESCRIPTION
Previously, dependencies with a namespace, might not have been updated, or detected having the wrong version.