### PR TITLE
Use `pre-commit`'s new (since 3.2.0) stage names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,7 +17,7 @@
     - toml@3.0.0
     - yaml@1.10.2
   stages:
-    - commit
+    - pre-commit
     - manual
-    - push
+    - pre-push
   files: ^(.pre-commit-config.yaml|.*/(yarn.lock|package-lock.json))$


### PR DESCRIPTION
The old names are deprecated, and will be removed in a future version