### PR TITLE
[feature] Support python packages with extras

### DIFF
--- a/shared.cjs
+++ b/shared.cjs
@@ -18,14 +18,39 @@ const readFile = path => fs.readFileSync(path, 'utf8');
  * @returns {Dependency}
  */
 function parseVersion(dependency) {
-	const {name, version} = /^(?<name>@?[a-z-/0-9]+)((@|==)(?<version>.+))?$/.exec(dependency)?.groups ?? {name: '', version: null};
+	const {name, version} = /^(?<name>@?[a-z-/0-9[\]]+)((@|==)(?<version>.+))?$/.exec(dependency)?.groups ?? {name: '', version: null};
 	return {
 		name,
 		version: version ?? null,
 	};
 }
 
+/**
+ * Simple function to escape regular expressions so that they can be used as regular strings in a (different)
+ * regular expression
+ *
+ * @param {string} string
+ * @returns {string}
+ */
+function escapeRegex(string) {
+	/** @type {function(string): string} */
+	let escape;
+	if ('escape' in RegExp && typeof RegExp.escape === 'function') {
+		// @ts-expect-error TypeScript is not aware of the new escape function
+		({escape} = RegExp);
+	} else {
+		escape = string => (
+			string
+				.replace(/\[/g, '\\[')
+				.replace(/]/g, '\\]')
+		);
+	}
+
+	return escape(string);
+}
+
 module.exports = {
 	readFile,
 	parseVersion,
+	escapeRegex,
 };


### PR DESCRIPTION
Closes: #42

`Extras` is part of the dependency specifiers for Python packages. For more information, see https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras