### PR TITLE
fix: Will no longer match and replace the first line it finds

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -360,7 +360,7 @@ async function updateDependencies() {
 				let content = readFile(PRE_COMMIT_YAML);
 				Object.keys(mapping).forEach(previousVersion => {
 					const newVersion = mapping[previousVersion];
-					content = content.replace(new RegExp(`( +- *["']?)${escapeRegex(previousVersion)}(["']? *#.*)?`, 'gi'), '$1' + newVersion + '$2');
+					content = content.replace(new RegExp(`( +- *["']?)${escapeRegex(previousVersion)}(["'])?( *#.*)?(\n)`, 'gi'), '$1' + newVersion + '$2$3$4');
 				});
 				fs.writeFileSync(PRE_COMMIT_YAML, content);
 			}


### PR DESCRIPTION
I discovered this while setting up `pre-commit` hooks for `eslint` in another repo where I happened to list `eslint` early, with quotes. Then `dependency-consistency` would replace the first instance of eslint correctly, but all plugins, which started with `eslint-` would be turned into `eslint@<version>-<rest of name>`.

The simple fix would be to change the order of dependencies, but it's better to fix it properly