### PR TITLE
Consistent Node.js runtime versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,50 @@
----
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-    - repo: local
-      hooks:
-          - id: check-typescript
-            name: Check TypeScript
-            language: node
-            entry: npm exec tsc
-            always_run: true
-            pass_filenames: false
+  - repo: local
+    hooks:
+      - id: check-typescript
+        name: Check TypeScript
+        language: node
+        language_version: 24.6.0
+        entry: npm exec tsc
+        always_run: true
+        pass_filenames: false
 
-          - id: keep-dependencies-consistent
-            name: Keep specified dependencies consistent
-            language: node
-            entry: node scripts/keep-own-dependencies-up-to-date.cjs
-            pass_filenames: false
-            files: ^(.pre-commit-hooks.yaml|package-lock.json)$
+      - id: keep-dependencies-consistent
+        name: Keep specified dependencies consistent
+        language: node
+        language_version: 24.6.0
+        entry: node scripts/keep-own-dependencies-up-to-date.cjs
+        pass_filenames: false
+        files: ^(.pre-commit-hooks.yaml|package-lock.json)$
 
-          - id: consistent-dependencies
-            name: Keep these dependencies consistent
-            language: node
-            entry: node index.cjs
-            language_version: 24.6.0
-            pass_filenames: false
-            files: ^(.pre-commit-config.yaml|package-lock.json)$
-            args:
-              - package-lock.json
+      - id: consistent-runtimes
+        name: Keep runtimes consistent
+        language: node
+        language_version: 24.6.0
+        entry: node scripts/keep-runtimes-consistent.cjs
+        pass_filenames: false
+        files: ^(.pre-commit-(config|hooks).yaml|.tool-versions)$
 
-    -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: 'v5.0.0'
-        hooks:
-          - id: check-json
-            exclude: tsconfig.json  # Uses JSON5
-          - id: check-yaml
+      - id: consistent-dependencies
+        name: Keep these dependencies consistent
+        language: node
+        entry: node index.cjs
+        language_version: 24.6.0
+        pass_filenames: false
+        files: ^(.pre-commit-config.yaml|package-lock.json)$
+        args:
+          - package-lock.json
 
-    -   repo: https://github.com/biomejs/pre-commit
-        rev: "v2.0.6"  # Use the sha / tag you want to point at
-        hooks:
-        -   id: biome-check
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v5.0.0'
+    hooks:
+      - id: check-json
+        exclude: tsconfig.json # Uses JSON5
+      - id: check-yaml
+
+  - repo: https://github.com/biomejs/pre-commit
+    rev: "v2.0.6" # Use the sha / tag you want to point at
+    hooks:
+      - id: biome-check

--- a/index.cjs
+++ b/index.cjs
@@ -10,6 +10,8 @@ const sqlite = require('node:sqlite');
 
 const {readFile, parseVersion, escapeRegex} = require('./shared.cjs');
 
+/** @import {SupportedLanguages, Repo, Hook, PreCommit} from './types' */
+
 if (process.argv.length < 3) {
 	throw new Error('At least one lock file must be given');
 }
@@ -17,7 +19,7 @@ if (process.argv.length < 3) {
 const PRE_COMMIT_YAML = '.pre-commit-config.yaml';
 const LOCK_FILES = process.argv.slice(2);
 
-/** @typedef {'node' | 'python'} SupportedLanguages */
+/** @constant {SupportedLanguages} */
 const SUPPORTED_LANGUAGES = /** @type {const} */ (['node', 'python']);
 
 /** @type {sqlite.DatabaseSync} */
@@ -268,21 +270,6 @@ function getDependencies(lockFiles) {
 }
 
 const dependencies = getDependencies(LOCK_FILES);
-
-/**
- * @typedef Hook
- * @property {string} id
- * @property {string[]} [additional_dependencies]
- * @property {SupportedLanguages} [language]
- *
- * @typedef Repo
- * @property {string} repo
- * @property {string} rev
- * @property {Hook[]} hooks
- *
- * @typedef PreCommit
- * @property {Repo[]} repos
- */
 
 /**
  *  @param {Repo} repo The repository for these hooks

--- a/scripts/keep-runtimes-consistent.cjs
+++ b/scripts/keep-runtimes-consistent.cjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// @ts-check
+
+const {readFile, updateYamlFile} = require('../shared.cjs');
+
+/** @import {PreCommit, Hook, ChangeYaml} from '../types' */
+
+function main() {
+	const reference = readFile('.tool-versions');
+	const nodeVersion = /nodejs +(\d+\.\d+\.\d+)/.exec(reference)?.[1];
+	if (!nodeVersion) {
+		throw new Error('Could not find the version of Node.js in .tool-versions');
+	}
+
+	updateYamlFile(
+		'.pre-commit-config.yaml',
+		/** @type {ChangeYaml<PreCommit>} */ preCommit => {
+			preCommit.repos.forEach(repo => {
+				repo.hooks.forEach(hook => {
+					if (hook.language === 'node') {
+						hook.language_version = nodeVersion;
+					}
+				});
+			});
+		},
+	);
+
+	updateYamlFile(
+		'.pre-commit-hooks.yaml',
+		/** @type {ChangeYaml<Hook[]>} */ hooks => {
+			hooks.forEach(hook => {
+				if (hook.language === 'node') {
+					hook.language_version = nodeVersion;
+				}
+			});
+		},
+	);
+}
+
+main();

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,3 +16,5 @@ export interface Repo {
 export interface PreCommit {
 	repos: Repo[];
 }
+
+export type ChangeYaml<T> = (root: T) => void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,18 @@
+export type SupportedLanguages = 'node' | 'python';
+
+export interface Hook {
+	id: string;
+	additional_dependencies: string[];
+	language: SupportedLanguages;
+	language_version?: string;
+}
+
+export interface Repo {
+	repo: string;
+	rev: string;
+	hooks: Hook[];
+}
+
+export interface PreCommit {
+	repos: Repo[];
+}


### PR DESCRIPTION
This ensures that the version specified in `.tool-versions` is explicitly used in all the `node` hooks.
This is especially relevant when #65 is used.
It might be unnecessary once Node.js 24 becomes the default, conservative version, but until then we need to specify which version to use