### PR TITLE
Reduce execution time

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
     - "@yarnpkg/lockfile@1.1.0"
     - pip-requirements-js@0.2.1
     - semver-sort@1.0.0
-    - toml@3.0.0
+    - smol-toml@1.4.2
     - yaml@1.10.2
   stages:
     - pre-commit

--- a/index.cjs
+++ b/index.cjs
@@ -3,7 +3,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const lockfile = require('@yarnpkg/lockfile');
 const YAML = require('yaml');
-const toml = require('toml');
+const toml = require('smol-toml');
 const requirements = require('pip-requirements-js');
 const semverSort = require('semver-sort');
 const sqlite = require('node:sqlite');
@@ -115,8 +115,9 @@ function parsePoetryLockFile(lockFile) {
 	 * @property {Package[]} package
 	 * */
 
-	/** @type {PoetryLock} */
-	const dependencies = toml.parse(readFile(lockFile));
+	const dependencies = /** @type {PoetryLock} */ (
+		toml.parse(readFile(lockFile))
+	);
 	return dependencies.package.reduce(
 		(dependencies, {name, version, extras}) => ({
 			...dependencies,
@@ -157,8 +158,7 @@ function parseUvLockFile(lockFile) {
 	 * @property {string} requires-python
 	 * @property {Package[]} package
 	 */
-	/** @type {UvLock} */
-	const dependencies = toml.parse(readFile(lockFile));
+	const dependencies = /** @type {UvLock} */ (toml.parse(readFile(lockFile)));
 	return dependencies.package.reduce(
 		(
 			dependencies,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@yarnpkg/lockfile": "^1.1.0",
 				"pip-requirements-js": "^0.2.1",
 				"semver-sort": "^1.0.0",
-				"toml": "^3.0.0",
+				"smol-toml": "^1.4.2",
 				"yaml": "^1.10.2"
 			},
 			"bin": {
@@ -133,11 +133,17 @@
 				"semver": "bin/semver"
 			}
 		},
-		"node_modules/toml": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-			"license": "MIT"
+		"node_modules/smol-toml": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+			"integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@yarnpkg/lockfile": "^1.1.0",
 		"pip-requirements-js": "^0.2.1",
 		"semver-sort": "^1.0.0",
-		"toml": "^3.0.0",
+		"smol-toml": "^1.4.2",
 		"yaml": "^1.10.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This replaces [`toml`](https://www.npmjs.com/package/toml) with [`smol-toml`](https://www.npmjs.com/package/smol-toml)

When profiling the code, I noticed that _a lot_ of the time was spent in `toml`'s `parse` function (~58% of the time).
The last time it was updated was January 2019.

The initial loading of the dependencies goes from taking multiple seconds to less than 100 ms for a large-ish TOML-based lock file

`smol-toml` is typed, so we need to [cast our variables](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#casts)