### PR TITLE
[Hotfix] Remove extraneous `async`

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -380,7 +380,7 @@ function updateDependencies(db, dependencies, preCommitFile) {
 	const preCommit = YAML.parse(readFile(preCommitFile));
 
 	preCommit.repos.forEach(repo => {
-		repo.hooks.forEach(async hook => {
+		repo.hooks.forEach(hook => {
 			const hookLanguage = getHookLanguage(db, repo, hook);
 			if (
 				hookLanguage === null ||


### PR DESCRIPTION
This should have been done as part of 1bc094c9cfeee4de5164c2813dba07fc372a312a